### PR TITLE
Dev contraceptive methods

### DIFF
--- a/src/app.elm
+++ b/src/app.elm
@@ -16,15 +16,16 @@ main =
 
 
 type alias Model =
-    { view : String }
+    { view : String, hormonalOptions : String }
 
 
 type Msg
     = ChangeView String
+    | ChangeOptions String
 
 
 model =
-    { view = "" }
+    { view = "", hormonalOptions = "nonhormonal" }
 
 
 update : Msg -> Model -> Model
@@ -32,6 +33,9 @@ update msg model =
     case msg of
         ChangeView newView ->
             { model | view = newView }
+
+        ChangeOptions options ->
+            { model | hormonalOptions = options }
 
 
 view model =
@@ -136,7 +140,7 @@ contraceptiveTypes model =
             ]
         , div [ Html.Attributes.class "half-screen half-screen--hormonal" ]
             [ button
-                [ Html.Attributes.class "half-screen--button", onClick (ChangeView "hormonal") ]
+                [ Html.Attributes.class "half-screen--button", onClick (ChangeView "contraceptiveMethods") ]
                 [ Html.text "Hormonal" ]
             , p [ Html.Attributes.class "contraceptive-tag" ] [ Html.text "Contraceptive methods that utilise hormones to prevent pregnancy" ]
             ]
@@ -150,14 +154,25 @@ contraceptiveMethods model =
             [ h1 [] [ Html.text "CONTRACEPTIVE METHODS" ] ]
         , div [ Html.Attributes.class "contra-methods-tab-container" ]
             [ div [ Html.Attributes.class "contra-methods-tab" ]
-                [ h2 [] [ Html.text "Non-hormonal" ] ]
+                [ h2 [ onClick <| ChangeOptions "nonhormonal" ] [ Html.text "Non-hormonal" ] ]
             , div [ Html.Attributes.class "contra-methods-tab" ]
-                [ h2 [] [ Html.text "Hormonal" ] ]
+                [ h2 [ onClick <| ChangeOptions "hormonal" ] [ Html.text "Hormonal" ] ]
             ]
-        , div [ Html.Attributes.class "contra-methods-container" ] (List.map nonhormonalMethodsDisplay nonhormonalMethodsList)
-        , div [ Html.Attributes.class "contra-methods-container" ]
-            (List.map hormonalMethodsDisplay hormonalMethodsList)
+        , hormonalOptions model
         ]
+
+
+hormonalOptions model =
+    case model.hormonalOptions of
+        "hormonal" ->
+            div [ Html.Attributes.class "contra-methods-container" ] (List.map nonhormonalMethodsDisplay nonhormonalMethodsList)
+
+        "nonhormonal" ->
+            div [ Html.Attributes.class "contra-methods-container" ]
+                (List.map hormonalMethodsDisplay hormonalMethodsList)
+
+        _ ->
+            div [] []
 
 
 nonhormonalMethodsList =

--- a/src/app.elm
+++ b/src/app.elm
@@ -25,7 +25,7 @@ type Msg
 
 
 model =
-    { view = "", hormonalOptions = "nonhormonal" }
+    { view = "", hormonalOptions = "" }
 
 
 update : Msg -> Model -> Model
@@ -165,11 +165,11 @@ contraceptiveMethods model =
 hormonalOptions model =
     case model.hormonalOptions of
         "hormonal" ->
-            div [ Html.Attributes.class "contra-methods-container" ] (List.map nonhormonalMethodsDisplay nonhormonalMethodsList)
+            div [ Html.Attributes.class "contra-methods-container" ] (List.map hormonalMethodsDisplay hormonalMethodsList)
 
         "nonhormonal" ->
             div [ Html.Attributes.class "contra-methods-container" ]
-                (List.map hormonalMethodsDisplay hormonalMethodsList)
+                (List.map nonhormonalMethodsDisplay nonhormonalMethodsList)
 
         _ ->
             div [] []


### PR DESCRIPTION
This PR adds a toggle functionality (between hormonal/ non-hormonal) to the contraceptive methods page. 

Next step is to route the user to the right version of the contraceptiveMethods model depending on which type the select in the previous page (hormonal/ non-hormonal)

Please don't delete the branch. 

relates #51 